### PR TITLE
Support for io.js and node v0.12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/harmonize.js
+++ b/harmonize.js
@@ -20,20 +20,28 @@
  * see: https://github.com/dcodeIO/node-harmonize for details
  */
 var child_process = require("child_process");
+var isIojs        = require("isIojs");
 
 module.exports = function() {
     if (typeof Proxy == 'undefined') { // We take direct proxies as our marker
         var v = process.versions.node.split(".");
-        if (v[0] == 0 && v[1] < 8) {
+
+        if (!isIojs && v[0] == 0 && v[1] < 8) {
             throw("harmonize requires at least node v0.8");
         }
+
+        // harmony flag is unnecessary in io and beginning with node v0.12
+        if(isIojs || (!isIojs && v[0] == 0 && v[1] >= 12)) {
+            return;
+        }
+
         var node = child_process.spawn(process.argv[0], ['--harmony'].concat(process.argv.slice(1)), {});
         node.stdout.pipe(process.stdout);
         node.stderr.pipe(process.stderr);
         node.on("close", function(code) {
             process.exit(code);
         });
-        
+
         // Interrupt process flow in the parent
         process.once("uncaughtException", function(e) {});
         throw("harmony");

--- a/harmonize.js
+++ b/harmonize.js
@@ -20,7 +20,7 @@
  * see: https://github.com/dcodeIO/node-harmonize for details
  */
 var child_process = require("child_process");
-var isIojs        = require("isIojs");
+var isIojs        = require("is-iojs");
 
 module.exports = function() {
     if (typeof Proxy == 'undefined') { // We take direct proxies as our marker

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
         "url": "https://github.com/dcodeIO/node-harmonize/issues"
     },
     "keywords": ["node", "harmony"],
-    "dependencies": {},
+    "dependencies": {
+        "is-iojs": "^1.0.0"
+    },
     "engines": {
         "node": ">=0.8"
     },


### PR DESCRIPTION
Added checks for io.js and node starting with v0.12. I'm not sure this is a resolution that will accommodate all uses of this library, but it did resolve facebook/jest/issues/235 for me.

This commit resolves #1
