### PR TITLE
Fix proxy for node v0.12.0

### DIFF
--- a/harmonize.js
+++ b/harmonize.js
@@ -31,11 +31,11 @@ module.exports = function() {
         }
 
         // harmony flag is unnecessary in io and beginning with node v0.12
-        if(isIojs || (!isIojs && v[0] == 0 && v[1] >= 12)) {
+        if(isIojs || (!isIojs && v[0] == 0 && v[1] > 12)) {
             return;
         }
 
-        var node = child_process.spawn(process.argv[0], ['--harmony'].concat(process.argv.slice(1)), {});
+        var node = child_process.spawn(process.argv[0], ['--harmony', '--harmony-proxies'].concat(process.argv.slice(1)), {});
         node.stdout.pipe(process.stdout);
         node.stderr.pipe(process.stderr);
         node.on("close", function(code) {

--- a/harmonize.js
+++ b/harmonize.js
@@ -21,6 +21,7 @@
  */
 var child_process = require("child_process");
 var isIojs        = require("is-iojs");
+var tty           = require('tty');
 
 module.exports = function() {
     if (typeof Proxy == 'undefined') { // We take direct proxies as our marker
@@ -35,7 +36,7 @@ module.exports = function() {
             return;
         }
 
-        var node = child_process.spawn(process.argv[0], ['--harmony', '--harmony-proxies'].concat(process.argv.slice(1)), {});
+        var node = child_process.spawn(process.argv[0], ['--harmony', '--harmony-proxies'].concat(process.argv.slice(1)), { pty: tty.isatty(0) });
         node.stdout.pipe(process.stdout);
         node.stderr.pipe(process.stderr);
         node.on("close", function(code) {


### PR DESCRIPTION
Alternatively the arguments could be used to specify extra flags, like this `require('harmonize')('--harmony-proxies')`. But then there has te be a reliable way to determine if the process is already running with the flags, the only thing I can think of is an environment variable.

Also resolves color issues, by spawning with `{ pty: true }` when the current process is running in a terminal interface.
