### PR TITLE
fixed unneccesary harmony flag on node.js version 0.12

### DIFF
--- a/harmonize.js
+++ b/harmonize.js
@@ -35,7 +35,7 @@ module.exports = function(features) {
             throw("harmonize requires at least node v0.8");
 
         // harmony flag is unnecessary in io and beginning with node v0.12
-        if(isIojs || (!isIojs && v[0] == 0 && v[1] > 12))
+        if(isIojs || (!isIojs && v[0] == 0 && v[1] >= 12))
             return;
 
         if (!features)


### PR DESCRIPTION
I think this was intended as this was mentioned in the comment. Also, I needed this to debug my jest tests in intellij.
